### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL scheme check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,4 +14,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
-          path-to-document: 'https://github.com/andywithcamera/velm/blob/main/CLA.md'
+          path-to-document: 'https://github.com/andywithcamera/velm/CLA.md'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,4 +14,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
-          path-to-document: 'https://github.com/andywithcamera/velm/CLA.md'
+          path-to-document: 'https://github.com/andywithcamera/velm/blob/main/CLA.md'

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -211,7 +211,16 @@
 
                 function resolveNavigationDestination(rawHref) {
                     const href = String(rawHref || "").trim();
-                    if (href === "" || href.startsWith("#") || href.startsWith("mailto:") || href.startsWith("tel:") || href.startsWith("javascript:")) {
+                    const normalizedHref = href.toLowerCase();
+                    if (
+                        href === "" ||
+                        href.startsWith("#") ||
+                        normalizedHref.startsWith("mailto:") ||
+                        normalizedHref.startsWith("tel:") ||
+                        normalizedHref.startsWith("javascript:") ||
+                        normalizedHref.startsWith("data:") ||
+                        normalizedHref.startsWith("vbscript:")
+                    ) {
                         return null;
                     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/andywithcamera/velm/security/code-scanning/2](https://github.com/andywithcamera/velm/security/code-scanning/2)

General fix: normalize the candidate URL string (trim + lowercase) before scheme checks, then reject all executable schemes (`javascript:`, `data:`, `vbscript:`).

Best minimal change in `web/templates/layout.html` (inside `resolveNavigationDestination`):  
- Keep existing behavior for empty, fragment, `mailto:`, and `tel:` links.  
- Add a normalized variable (lowercased `href`) and use it for scheme checks.  
- Extend the condition to include `data:` and `vbscript:`.  

This preserves existing functionality while closing the incomplete scheme check gap.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
