### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/web/templates/map-view.html
+++ b/web/templates/map-view.html
@@ -360,7 +360,9 @@
       }
       if (link) {
         if (selected && table) {
-          link.href = `/f/${table}/${selected.value}`;
+          const safeTable = encodeURIComponent(table);
+          const safeValue = encodeURIComponent(selected.value);
+          link.href = `/f/${safeTable}/${safeValue}`;
           link.classList.remove("hidden");
         } else {
           link.classList.add("hidden");


### PR DESCRIPTION
Potential fix for [https://github.com/andywithcamera/velm/security/code-scanning/4](https://github.com/andywithcamera/velm/security/code-scanning/4)

The best fix is to **encode each untrusted path component** before inserting it into the URL path. This preserves functionality (still links to `/f/{table}/{id}`) while preventing reinterpretation or structural manipulation via `/`, `?`, `#`, quotes, etc.

In `web/templates/map-view.html`, inside `updatePickerPresentation` where `link.href` is set, replace:

- ``link.href = `/f/${table}/${selected.value}`;``

with a safe construction using `encodeURIComponent` on both `table` and `selected.value`. No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
