### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/web/templates/map-view.html
+++ b/web/templates/map-view.html
@@ -244,6 +244,14 @@
       return (picker?.getAttribute("data-reference-table") || "").trim();
     }
 
+    function safeTableSegment(table) {
+      return (table || "").trim().replace(/[^A-Za-z0-9_-]/g, "");
+    }
+
+    function safePathSegment(value) {
+      return encodeURIComponent((value || "").trim());
+    }
+
     function pickerTableLabel(picker) {
       return (picker?.getAttribute("data-reference-table-label") || "Record").trim();
     }
@@ -314,8 +322,10 @@
       modalCurrent.classList.remove("hidden");
       modalCurrentLabel.textContent = selected.label;
       modalCurrentMeta.textContent = selected.value;
-      if (table) {
-        modalOpenRecord.href = `/f/${table}/${selected.value}`;
+      const safeTable = safeTableSegment(table);
+      const safeValue = safePathSegment(selected.value);
+      if (safeTable && safeValue) {
+        modalOpenRecord.href = `/f/${safeTable}/${safeValue}`;
         modalOpenRecord.classList.remove("hidden");
       } else {
         modalOpenRecord.classList.add("hidden");


### PR DESCRIPTION
Potential fix for [https://github.com/andywithcamera/velm/security/code-scanning/3](https://github.com/andywithcamera/velm/security/code-scanning/3)

Best fix: strictly constrain and encode the dynamic URL parts before assigning `href`.

In `web/templates/map-view.html`, in the script region around `pickerTable`, `selectedReferenceData`, and `renderModalCurrent`:

1. Add helper(s) to sanitize path segments:
   - one for table names with allowlist characters (e.g. `[A-Za-z0-9_-]`)
   - one generic path-segment encoder using `encodeURIComponent`.
2. In `renderModalCurrent()`, replace direct interpolation:
   - from `` `/f/${table}/${selected.value}` ``
   - to a safely constructed path using sanitized/encoded segments.
3. Keep behavior the same (internal `/f/.../...` links), but if table is invalid/empty after sanitization, keep the existing hidden/no-href behavior.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
