### PR TITLE
Potential fix for code scanning alert no. 45: Size computation for allocation may overflow

### DIFF
--- a/internal/db/SecurityRules.go
+++ b/internal/db/SecurityRules.go
@@ -386,7 +386,15 @@ func MergeRecordSnapshot(base map[string]any, formData map[string]string, nullCo
 	if len(base) == 0 && len(formData) == 0 {
 		return map[string]any{}
 	}
-	merged := make(map[string]any, len(base)+len(formData))
+
+	maxInt := int(^uint(0) >> 1)
+	var merged map[string]any
+	if len(base) > maxInt-len(formData) {
+		merged = make(map[string]any)
+	} else {
+		merged = make(map[string]any, len(base)+len(formData))
+	}
+
 	for key, value := range base {
 		merged[key] = value
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/andywithcamera/velm/security/code-scanning/45](https://github.com/andywithcamera/velm/security/code-scanning/45)

Use overflow-safe capacity computation before map allocation in `MergeRecordSnapshot`:

- Compute capacity without direct `len(base)+len(formData)` overflow risk.
- If addition would overflow (`len(base) > maxInt-len(formData)`), fall back to allocation without capacity hint (`make(map[string]any)`), preserving functionality while avoiding panic/incorrect size.
- Otherwise allocate with exact combined capacity as before.

Apply this in `internal/db/SecurityRules.go` at `MergeRecordSnapshot` (around current line 389).  
No new dependencies are needed; add a small local `maxInt` expression using bit ops.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
