### PR TITLE
Potential fix for code scanning alert no. 47: Cookie 'Secure' attribute is not set to true

### DIFF
--- a/internal/auth/RequireAuth.go
+++ b/internal/auth/RequireAuth.go
@@ -117,6 +117,7 @@ func clearSessionCookie(w http.ResponseWriter, opts *sessions.Options) {
 		Value:    "",
 		Path:     "/",
 		MaxAge:   -1,
+		Secure:   true,
 		HttpOnly: true,
 	}
 
@@ -125,7 +126,6 @@ func clearSessionCookie(w http.ResponseWriter, opts *sessions.Options) {
 			cookie.Path = opts.Path
 		}
 		cookie.Domain = opts.Domain
-		cookie.Secure = opts.Secure
 		cookie.HttpOnly = opts.HttpOnly
 		cookie.SameSite = opts.SameSite
 		cookie.Partitioned = opts.Partitioned


### PR DESCRIPTION
Potential fix for [https://github.com/andywithcamera/velm/security/code-scanning/47](https://github.com/andywithcamera/velm/security/code-scanning/47)

Set the cleared session cookie’s `Secure` attribute to `true` by default and do not overwrite it from `store.Options`.  
Best minimal fix in `internal/auth/RequireAuth.go`:

- In `clearSessionCookie`, initialize `cookie.Secure` to `true` in the literal.
- In the `opts != nil` block, remove the line that copies `opts.Secure` into the cookie, so it cannot downgrade to `false`.
- Keep the rest of the behavior (Path/Domain/HttpOnly/SameSite/Partitioned) unchanged.

This preserves functionality (cookie clearing still works) while ensuring the `Secure` flag is always present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
