### PR TITLE
Potential fix for code scanning alert no. 49: Bad redirect check

### DIFF
--- a/cmd/server/handleLoginPage.go
+++ b/cmd/server/handleLoginPage.go
@@ -21,7 +21,7 @@ func sanitizeLoginNext(raw string) string {
 	if raw == "" {
 		return "/"
 	}
-	if !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") {
+	if !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") || strings.HasPrefix(raw, "/\\") {
 		return "/"
 	}
 	if raw == "/login" || strings.HasPrefix(raw, "/login?") {


### PR DESCRIPTION
Potential fix for [https://github.com/andywithcamera/velm/security/code-scanning/49](https://github.com/andywithcamera/velm/security/code-scanning/49)

Use a stricter same-origin path check in `sanitizeLoginNext` so accepted values must:
- start with `/`
- **not** start with `//`
- **not** start with `/\`

Best minimal fix: update the condition in `cmd/server/handleLoginPage.go` (inside `sanitizeLoginNext`) to reject both disallowed second-character cases. No new imports/dependencies are needed, and existing behavior (default `/`, `/login` loop prevention) remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
