### PR TITLE
Potential fix for code scanning alert no. 55: Open URL redirect

### DIFF
--- a/cmd/server/handleLoginPage.go
+++ b/cmd/server/handleLoginPage.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -18,14 +19,30 @@ func handleLoginPage(w http.ResponseWriter, r *http.Request) {
 }
 
 func sanitizeLoginNext(raw string) string {
+	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "/"
 	}
-	if !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") || strings.HasPrefix(raw, "/\\") {
+
+	// Normalize backslashes because some clients treat "\" as "/".
+	raw = strings.ReplaceAll(raw, "\\", "/")
+
+	u, err := url.Parse(raw)
+	if err != nil {
 		return "/"
 	}
-	if raw == "/login" || strings.HasPrefix(raw, "/login?") {
+
+	// Allow only local, relative redirects.
+	if u.Hostname() != "" || u.Scheme != "" {
 		return "/"
 	}
-	return raw
+	if !strings.HasPrefix(u.Path, "/") || strings.HasPrefix(u.Path, "//") {
+		return "/"
+	}
+
+	safe := u.String()
+	if safe == "/login" || strings.HasPrefix(safe, "/login?") {
+		return "/"
+	}
+	return safe
 }


### PR DESCRIPTION
Potential fix for [https://github.com/andywithcamera/velm/security/code-scanning/55](https://github.com/andywithcamera/velm/security/code-scanning/55)

Use strict allow-local validation by normalizing and parsing the candidate target, and only allow relative in-app paths (empty host/scheme, leading `/`, and no protocol-relative path). Keep behavior the same by returning `"/"` when invalid.

Best single fix: update `sanitizeLoginNext` in `cmd/server/handleLoginPage.go` to:
- trim and default empty to `/`
- replace backslashes with `/` before parsing
- parse with `net/url`
- reject if parse fails, host is present, or scheme is present
- require path to start with `/` and not `//`
- keep existing `/login` rejection

No handler logic changes are required; both GET/login page and POST/login reuse this function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
