### PR TITLE
Potential fix for code scanning alert no. 59: Size computation for allocation may overflow

### DIFF
--- a/internal/db/SecurityRules.go
+++ b/internal/db/SecurityRules.go
@@ -387,20 +387,7 @@ func MergeRecordSnapshot(base map[string]any, formData map[string]string, nullCo
 		return map[string]any{}
 	}
 
-	maxInt := int(^uint(0) >> 1)
-	baseLen := len(base)
-	formLen := len(formData)
-	capacityHint := 0
-	if baseLen <= maxInt-formLen {
-		capacityHint = baseLen + formLen
-	}
-
-	var merged map[string]any
-	if capacityHint > 0 {
-		merged = make(map[string]any, capacityHint)
-	} else {
-		merged = make(map[string]any)
-	}
+	merged := make(map[string]any)
 
 	for key, value := range base {
 		merged[key] = value


### PR DESCRIPTION
Potential fix for [https://github.com/andywithcamera/velm/security/code-scanning/59](https://github.com/andywithcamera/velm/security/code-scanning/59)

Best fix: remove overflow-prone capacity arithmetic in `MergeRecordSnapshot` and allocate the destination map without a computed combined-capacity hint. This preserves behavior (same merged content) while eliminating the risky operation entirely.

Concrete change in `internal/db/SecurityRules.go` in `MergeRecordSnapshot`:
- Delete `maxInt`, `baseLen`, `formLen`, `capacityHint`, and the conditional allocation block.
- Replace with a single `merged := make(map[string]any)` allocation.
- Keep the copy/merge loops unchanged.

No imports, new methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
