### PR TITLE
Potential fix for code scanning alert no. 50: Bad redirect check

### DIFF
--- a/cmd/server/handleRootRoute.go
+++ b/cmd/server/handleRootRoute.go
@@ -171,7 +171,7 @@ func normalizeAuthenticatedRouteTarget(input string) string {
 
 func normalizeAuthenticatedRoutePath(input string) string {
 	target := strings.TrimSpace(input)
-	if target == "" || strings.HasPrefix(target, "//") {
+	if target == "" || strings.HasPrefix(target, "//") || strings.HasPrefix(target, "/\\") {
 		return ""
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/andywithcamera/velm/security/code-scanning/50](https://github.com/andywithcamera/velm/security/code-scanning/50)

The safest fix is to strengthen `normalizeAuthenticatedRoutePath` so it rejects both `//` and `/\` prefixed values before URI parsing. This preserves current behavior for valid internal paths while preventing protocol-relative / browser-ambiguous redirect targets.

Best single fix without changing functionality:
- **File:** `cmd/server/handleRootRoute.go`
- **Region:** `normalizeAuthenticatedRoutePath` (around lines 172–176)
- Update the early rejection condition from only `//` to both `//` and `/\`.
- No new imports or dependencies are needed.

This single change addresses both alert variants because both redirect sinks depend on `defaultAuthenticatedRoute(...)`, which uses this normalization routine.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
