### PR TITLE
Potential fix for code scanning alert no. 50: Bad redirect check

### DIFF
--- a/cmd/server/handleRootRoute.go
+++ b/cmd/server/handleRootRoute.go
@@ -76,7 +76,7 @@ func requestIsAuthenticated(r *http.Request) bool {
 func defaultAuthenticatedRoute(ctx context.Context) string {
 	target := resolveAuthenticatedRouteTarget(ctx)
 	switch {
-	case strings.HasPrefix(target, "/"):
+	case strings.HasPrefix(target, "/") && !strings.HasPrefix(target, "//") && !strings.HasPrefix(target, "/\\"):
 		if path := normalizeAuthenticatedRoutePath(target); path != "" {
 			return path
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/andywithcamera/velm/security/code-scanning/50](https://github.com/andywithcamera/velm/security/code-scanning/50)

General fix: whenever allowing redirects based on “starts with `/`”, also reject paths whose second character is `/` or `\` (i.e., reject `//...` and `/\...`).

Best single fix here: in `cmd/server/handleRootRoute.go`, update the `defaultAuthenticatedRoute` switch guard at line 79 so the “path” branch only triggers for slash-prefixed values that are not `//` or `/\`. This aligns the guard with the sanitizer and resolves both alert variants since `loginPostHandler` calls `defaultAuthenticatedRoute(...)`.

No new methods/imports/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
