### PR TITLE
chore: stop tracking compiled server binary, add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ go.work.sum
 tmp/
 tools/tailwindcss
 .DS_Store
+
+# Root-level compiled binaries (build artifacts)
+/server
+/bin/


### PR DESCRIPTION
**Why:** the ~30MB compiled `server` binary is a committed build artifact.

- Bloat: every clone/fetch/CI checkout pulls 30MB of binary it has no use for.
- Conflicts: any two rebuilds of `server` produce unmergeable binary diffs.
- Footgun: operators could accidentally run a stale `server` that drifted from source.
- Hygiene: `.gitignore` was missing Go build-artifact rules, which is how it got committed.

**What:**
- `git rm --cached server` — stop tracking it (local copy kept on disk).
- Add `/bin/` and `/server` to `.gitignore` so build artifacts can't be re-added.

**Note:** this removes the binary from current tracking but not from git history; history rewrite can happen separately if clone size matters.