### PR TITLE
Address Codex review on #64 (follow-up): keepalive save + Catppuccin backdrop

### DIFF
--- a/web/static/css/ui/40-velm-monochrome.css
+++ b/web/static/css/ui/40-velm-monochrome.css
@@ -777,6 +777,10 @@ html[data-theme="light"] .ui-reference-modal-backdrop {
   background: rgba(255, 255, 255, 0.92);
 }
 
+html[data-theme="catppuccin"] .ui-reference-modal-backdrop {
+  background: rgba(255, 255, 255, 0.92);
+}
+
 html[data-theme="dark"] .ui-reference-modal-backdrop,
 html[data-theme="nord"] .ui-reference-modal-backdrop,
 html[data-theme="tokyo-night"] .ui-reference-modal-backdrop {

--- a/web/templates/layout.html
+++ b/web/templates/layout.html
@@ -144,6 +144,7 @@
                     const csrf = (document.querySelector('meta[name="csrf-token"]') || {}).content || "";
                     fetch("/api/preferences/theme", {
                         method: "POST",
+                        keepalive: true,
                         headers: {
                             "Content-Type": "application/json",
                             "X-CSRF-Token": csrf


### PR DESCRIPTION
Follow-up to merged #64: applies the two Codex review P2 comments that landed after the merge and were missed.

**1. Teardown-safe theme save** (`layout.html`) — the theme-preference `fetch` was fire-and-forget; changing theme then immediately navigating/reloading/closing could cancel the in-flight request so the next page rendered the old theme. Now uses `fetch(..., { keepalive: true })` so the save survives page teardown.

**2. Catppuccin light backdrop** (`40-velm-monochrome.css`) — Catppuccin is a **light** theme but was falling through to the dark `reference-modal-backdrop`; added an explicit white-backdrop rule for it.

Closes #65 is tracked separately; this is a CSS/JS-only change (no Go rebuild required).